### PR TITLE
Update Layout_Generator.php

### DIFF
--- a/classes/Layout_Generator.php
+++ b/classes/Layout_Generator.php
@@ -64,12 +64,12 @@ if ( ! class_exists('WPPB_Layout_Generator')){
 					
 					<?php if( !empty($setting['settings']['row_shape'])  && $setting['settings']['row_shape']['itemOpenShape'] == 1 && $setting['settings']['row_screen'] != 'row-default' ){ ?>
                         <div class="wppb-shape-container wppb-top-shape">
-							<?php echo file_get_contents( WPPB_DIR_URL.'assets/shapes/'.$setting['settings']['row_shape']['shapeStyle'].'.svg' ); ?>
+							<?php echo file_get_contents( __DIR__.'/../assets/shapes/'.$setting['settings']['row_shape']['shapeStyle'].'.svg' ); ?>
 						</div>
 					<?php } ?>
 					<?php if( !empty($setting['settings']['row_shape_bottom'])  && $setting['settings']['row_shape_bottom']['itemOpenShape'] == 1 && $setting['settings']['row_screen'] != 'row-default' ){ ?>
                         <div class="wppb-shape-container wppb-bottom-shape">
-							<?php echo file_get_contents( WPPB_DIR_URL.'assets/shapes/'.$setting['settings']['row_shape_bottom']['shapeStyle'].'.svg' ); ?>
+							<?php echo file_get_contents( __DIR__.'/../assets/shapes/'.$setting['settings']['row_shape_bottom']['shapeStyle'].'.svg' ); ?>
 						</div>
 					<?php } ?>
 
@@ -84,12 +84,12 @@ if ( ! class_exists('WPPB_Layout_Generator')){
 					<div class="wppb-container <?php echo $row_container_class.implode( ' ', $full_container_stretch ); ?>">
 						<?php if( !empty($setting['settings']['row_shape'])  && $setting['settings']['row_shape']['itemOpenShape'] == 1 && $setting['settings']['row_screen'] == 'row-default' ){ ?>
 							<div class="wppb-shape-container wppb-top-shape">
-								<?php echo file_get_contents( WPPB_DIR_URL.'assets/shapes/'.$setting['settings']['row_shape']['shapeStyle'].'.svg' ); ?>
+								<?php echo file_get_contents( __DIR__.'/../assets/shapes/'.$setting['settings']['row_shape']['shapeStyle'].'.svg' ); ?>
 							</div>
 						<?php } ?>
 						<?php if( !empty($setting['settings']['row_shape_bottom'])  && $setting['settings']['row_shape_bottom']['itemOpenShape'] == 1 && $setting['settings']['row_screen'] == 'row-default' ){ ?>
 							<div class="wppb-shape-container wppb-bottom-shape">
-								<?php echo file_get_contents( WPPB_DIR_URL.'assets/shapes/'.$setting['settings']['row_shape_bottom']['shapeStyle'].'.svg' ); ?>
+								<?php echo file_get_contents( __DIR__.'/../assets/shapes/'.$setting['settings']['row_shape_bottom']['shapeStyle'].'.svg' ); ?>
 							</div>
 						<?php } ?>
 	


### PR DESCRIPTION
file_get_contents with the fully qualified URL causes several issues:
1) it does not work on certain setups, especially with reverse-proxies, thus causing a multiple request_timed_out per page (for each shape on page, huh)
2) it does create unnecessary external requests when you could save precious milliseconds on handling local file request via php

proposed change is to relate on the magic constant __DIR__ and use relative path form the class itself to go up one level in folder structure and then act normally, this way include will consider any possible setup and should work better and faster